### PR TITLE
Hide manual provisioning switch when extphone framework is not present

### DIFF
--- a/src/com/android/settings/sim/SimSettings.java
+++ b/src/com/android/settings/sim/SimSettings.java
@@ -484,11 +484,13 @@ public class SimSettings extends RestrictedSettingsFragment implements Indexable
             mSwitch.setVisibility(mSwitchVisibility);
 
             // Disable manual provisioning option to user when
-            // device is in Airplane mode.
-            if (isAirplaneModeOn()) {
-                mSwitch.setEnabled(false);
+            // device is in Airplane mode. Hide it if the extphone framework
+            // is not present, as the operation relies on said framework.
+            if (mExtTelephony == null) {
+                mSwitch.setVisibility(View.GONE);
             } else {
-                mSwitch.setEnabled(true);
+                mSwitch.setVisibility(View.VISIBLE);
+                mSwitch.setEnabled(!isAirplaneModeOn());
             }
         }
 


### PR DESCRIPTION
- It doesn't work without it.

Change-Id: Iec11ec2006059f26668f2a6fee4c2c9ca6650119
