### PR TITLE
Settings: CryptKeeper improvements (squashed)

### DIFF
--- a/res/layout/crypt_keeper_pattern_sizes.xml
+++ b/res/layout/crypt_keeper_pattern_sizes.xml
@@ -24,7 +24,7 @@
             android:textSize="14sp"
             android:fontFamily="sans-serif"
             android:text="@string/lock_pattern_size_3"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/white"
             android:layout_weight="1"
             style="?android:attr/borderlessButtonStyle"/>
 
@@ -36,7 +36,7 @@
             android:textSize="14sp"
             android:fontFamily="sans-serif"
             android:text="@string/lock_pattern_size_4"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/white"
             android:layout_weight="1"
             style="?android:attr/borderlessButtonStyle"/>
 
@@ -48,7 +48,7 @@
             android:textSize="14sp"
             android:fontFamily="sans-serif"
             android:text="@string/lock_pattern_size_5"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/white"
             android:layout_weight="1"
             style="?android:attr/borderlessButtonStyle"/>
 
@@ -60,7 +60,7 @@
             android:textSize="14sp"
             android:fontFamily="sans-serif"
             android:text="@string/lock_pattern_size_6"
-            android:textColor="@color/text_color_white"
+            android:textColor="@color/white"
             android:layout_weight="1"
             style="?android:attr/borderlessButtonStyle"/>
 


### PR DESCRIPTION
Commits:
CryptKeeper: pattern unlock displays incorrect pw when correct
https://github.com/CyanogenMod/android_packages_apps_Settings/commit/2491ab7c142c8fa9ad9a1d9d40ff684ad891962c

Settings: fix non lock pattern CryptKeeper crash
https://github.com/CyanogenMod/android_packages_apps_Settings/commit/13847228afc320824775322ae2e087ec7010f894

CryptKeeper: layout whole screen in bounds
https://github.com/CyanogenMod/android_packages_apps_Settings/commit/35761ffce2089e037e0f37999704819b3e1ce11e

CryptKeeper improvements
https://github.com/CyanogenMod/android_packages_apps_Settings/commit/c342389b2d3df588ceec5d0e877096f29103ee65
